### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,5 +1,8 @@
 name: Python Tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/childmindresearch/cpac-log-muncher/security/code-scanning/9](https://github.com/childmindresearch/cpac-log-muncher/security/code-scanning/9)

To fix the problem, add a `permissions` block that explicitly limits the permissions of the GITHUB_TOKEN for this workflow. You can add the block at the root level (applies to all jobs unless overridden) or at individual job levels if different jobs require different permissions. In this case, since none of the jobs write content to the repository, the minimal permission required is `contents: read`. Add the following block directly below the workflow's name and trigger configuration at the root level of `.github/workflows/test.yaml`:

```yaml
permissions:
  contents: read
```

This change will ensure that all jobs use the least required privilege, following the principle of least privilege without altering any existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
