### PR TITLE
Fix deprecated SPDX license identifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Accumulate and summarize run (error) data across many CPAC execut
 authors = [
   {name = "CMI DAIR", email = "dair@childmind.org"}
 ]
-license = "LGPL-2.1"
+license = "LGPL-2.1-only"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
Updates deprecated SPDX license identifiers to fix build failures.

- `LGPL-2.1` → `LGPL-2.1-only`